### PR TITLE
Avoid Causing Errors when Logging Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.0.6] - 2016-01-05
+### Fixed
+- Avoid causing any exception when logging an exception
+
 ## [2.0.5] - 2015-11-05
 ### Fixed
 - Ensure any primitive and complex data type passed to the log context are logged properly.
@@ -29,6 +33,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial release/tag
 
+[2.0.6]: https://github.com/eBayEnterprise/magento-log/compare/2.0.5...2.0.6
 [2.0.5]: https://github.com/eBayEnterprise/magento-log/compare/2.0.4...2.0.5
 [2.0.4]: https://github.com/eBayEnterprise/magento-log/compare/2.0.3...2.0.4
 [2.0.3]: https://github.com/eBayEnterprise/magento-log/compare/2.0.2...2.0.3


### PR DESCRIPTION
When logging exceptions, the wrong type can cause the _logger_ itself to throw an error. This fixes that and attempts to prevent the logger itself from ever _throwing_ an error. If the logger ultimately can't handle some input, it will add `meta_log` data to the metadata to describe its failure.